### PR TITLE
Ensure LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
Execution of the oxid6_apache container fails on Windows when cloned with git:

```
oxid6_apache_1 exited with code 127
: No such file or directory/env: bash
```
converting shell script line endings after checkout to LF seems to make it work on Docker for Windows.