### PR TITLE
Fix GD dependencies.

### DIFF
--- a/container/apache_php7/Dockerfile
+++ b/container/apache_php7/Dockerfile
@@ -9,7 +9,7 @@ RUN echo "Europe/Berlin" > /etc/timezone && dpkg-reconfigure -f noninteractive t
 RUN apt-get update -y && \
   apt-get install -y --no-install-recommends \
   less vim wget unzip rsync git mysql-client \
-  libcurl4-openssl-dev libfreetype6 libjpeg62-turbo libpng12-dev libjpeg-dev libxml2-dev libwebp5 libxpm4 && \
+  libcurl4-openssl-dev libfreetype6 libjpeg62-turbo libpng-dev libjpeg-dev libxml2-dev libwebp6 libxpm4 && \
   apt-get clean && \
   apt-get autoremove -y && \
   rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
Latest php:7.1-apache has different library names for WebP and PNG.