### PR TITLE
Fix PHP extensions to build.

### DIFF
--- a/container/apache_php7/Dockerfile
+++ b/container/apache_php7/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update -y && \
 
 # install php extensions
 RUN docker-php-ext-configure gd --with-jpeg-dir=/usr/local/ && \
-  docker-php-ext-install -j$(nproc) curl json xml mbstring zip bcmath soap pdo_mysql gd
+  docker-php-ext-install -j$(nproc) zip bcmath soap pdo_mysql gd
 
 # composer stuff
 RUN php -r 'readfile("https://getcomposer.org/installer");' > composer-setup.php \


### PR DESCRIPTION
The curl, json, mbstring, and xml extensions are already loaded by default with the latest php:7.1-apache image.