### PR TITLE
Made compatibility changes for Debian Buster and increased OXID version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This setup bootstraps an dockerized developer environment for [OXID eShop 6](htt
 - MySQL 5.7 container ([Dockerfile](https://github.com/docker-library/mysql/blob/883703dfb30d9c197e0059a669c4bb64d55f6e0d/5.7/Dockerfile))
 - MailHog container ([Dockerfile](https://github.com/mailhog/MailHog/blob/master/Dockerfile))
 - phpMyAdmin container ([Dockerfile](https://hub.docker.com/r/phpmyadmin/phpmyadmin/~/dockerfile/))
-- OXID composer project ([6.0.2](https://github.com/OXID-eSales/oxideshop_metapackage_ce/blob/b-6.0/composer.json))
+- OXID composer project ([6.1.3](https://github.com/OXID-eSales/oxideshop_metapackage_ce/blob/b-6.1/composer.json))
 - OXID demo data
 
 ## Quickstart

--- a/container/apache_php7/Dockerfile
+++ b/container/apache_php7/Dockerfile
@@ -8,7 +8,7 @@ RUN echo "Europe/Berlin" > /etc/timezone && dpkg-reconfigure -f noninteractive t
 # install packages
 RUN apt-get update -y && \
   apt-get install -y --no-install-recommends \
-  less vim wget unzip rsync git mysql-client \
+  less vim wget unzip rsync git default-mysql-client \
   libcurl4-openssl-dev libfreetype6 libjpeg62-turbo libpng-dev libjpeg-dev libxml2-dev libxpm4 && \
   apt-get clean && \
   apt-get autoremove -y && \


### PR DESCRIPTION
Due to the release of Debian Buster the package **mysql-client** was renamed to **default-mysql-client** which leads to an abort of the build process. This is now fixed by this Pull request.

Also the OXID version current installed by this project is 6.1.3 which is corrected in the README file.