### PR TITLE
Added some speedups.

### DIFF
--- a/container/apache_php7/Dockerfile
+++ b/container/apache_php7/Dockerfile
@@ -9,15 +9,17 @@ RUN echo "Europe/Berlin" > /etc/timezone && dpkg-reconfigure -f noninteractive t
 RUN apt-get update -y && \
   apt-get install -y --no-install-recommends \
   less vim wget unzip rsync git default-mysql-client \
-  libcurl4-openssl-dev libfreetype6 libjpeg62-turbo libpng-dev libjpeg-dev libxml2-dev libxpm4 && \
+  libcurl4-openssl-dev libfreetype6 libjpeg62-turbo libpng-dev libjpeg-dev libxml2-dev libxpm4 libmemcached-dev && \
   apt-get clean && \
   apt-get autoremove -y && \
   rm -rf /var/lib/apt/lists/* && \
-  echo "export TERM=xterm" >> /root/.bashrc
+  echo "export TERM=xterm" >> /root/.bashrc && \
+  pecl install memcached-3.0.4 redis apcu
 
 # install php extensions
 RUN docker-php-ext-configure gd --with-jpeg-dir=/usr/local/ && \
-  docker-php-ext-install -j$(nproc) zip bcmath soap pdo_mysql gd
+  docker-php-ext-enable memcached redis apcu && \
+  docker-php-ext-install -j$(nproc) zip bcmath soap pdo_mysql gd opcache
 
 # composer stuff
 RUN php -r 'readfile("https://getcomposer.org/installer");' > composer-setup.php \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
 
-  oxid6_memcache:
+  oxid6_memcached:
     image: memcached
     restart: always
     mem_limit: 128m

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,13 @@ services:
       MYSQL_PASSWORD: ${MYSQL_PASSWORD}
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
 
+  oxid6_memcache:
+    image: memcached
+    restart: always
+    mem_limit: 128m
+    memswap_limit: 128m
+    mem_reservation: 96m
+  
   oxid6_mailhog:
     hostname: mailhog.${DOMAIN}
     image: mailhog/mailhog:latest


### PR DESCRIPTION
Added some speedups. Still testing why Oxid6 does not recognize memcached but opcache will do its work.

As per documentation Oxid6 still expects php5-memcached.

If that's changed you'll find "caching" tab in system settings automatically, then.
Simply point to oxid6_memcached and speed it up.
