### PR TITLE
fixed sAdminSSLURL to make the admin backend accessible again

### DIFF
--- a/container/apache_php7/files/config.inc.php
+++ b/container/apache_php7/files/config.inc.php
@@ -29,7 +29,7 @@ $this->dbUser = \getenv('MYSQL_USER'); // database user name
 $this->dbPwd = \getenv('MYSQL_PASSWORD'); // database user password
 $this->sShopURL = 'http://'.\getenv('DOMAIN').':'.\getenv('APACHE_PORT'); // eShop base url, required
 $this->sSSLShopURL = 'https://'.\getenv('DOMAIN').':'.\getenv('APACHE_HTTPS_PORT'); // eShop SSL url, optional
-$this->sAdminSSLURL = 'https://'.\getenv('DOMAIN').':'.\getenv('APACHE_HTTPS_PORT');            // eShop Admin SSL url, optional
+$this->sAdminSSLURL = 'https://'.\getenv('DOMAIN').':'.\getenv('APACHE_HTTPS_PORT').'/admin'; // eShop Admin SSL url, optional
 $this->sShopDir = '/var/www/html/source';
 $this->sCompileDir = '/var/www/html/source/tmp';
 


### PR DESCRIPTION
Due to an previous update of the sAdminSSLURL variable in the config.inc.php file the admin panel of a freshly installed docker oxid isn't accessible. With this change it is working again :)