### PR TITLE
fix composer to version 1

### DIFF
--- a/container/apache_php7/Dockerfile
+++ b/container/apache_php7/Dockerfile
@@ -21,7 +21,7 @@ RUN docker-php-ext-configure gd --with-jpeg-dir=/usr/local/ && \
 
 # composer stuff
 RUN php -r 'readfile("https://getcomposer.org/installer");' > composer-setup.php \
-  && php composer-setup.php --install-dir=/usr/local/bin --filename=composer \
+  && php composer-setup.php --1 --install-dir=/usr/local/bin --filename=composer \
   && rm -f composer-setup.php \
   && chown www-data:www-data /var/www
 


### PR DESCRIPTION
Due to the release of composer 2 which is not compatible with some packages you get some error while updating dependencies. To solve this issue we should fix composer to version 1 until the packages are compatible with version 2.

```bash
oxid6_apache_1      | Updating dependencies
oxid6_apache_1      | Your requirements could not be resolved to an installable set of packages.
oxid6_apache_1      | 
oxid6_apache_1      |   Problem 1
oxid6_apache_1      |     - Root composer.json requires oxid-esales/oxideshop-ide-helper ^v3.1.2 -> satisfiable by oxid-esales/oxideshop-ide-helper[v3.1.2].
oxid6_apache_1      |     - oxid-esales/oxideshop-ide-helper v3.1.2 requires composer-plugin-api ^1.1.0 -> found composer-plugin-api[2.0.0] but it does not match the constraint.
oxid6_apache_1      |   Problem 2
oxid6_apache_1      |     - ocramius/package-versions[1.4.2, ..., 1.5.1] require composer-plugin-api ^1.0.0 -> found composer-plugin-api[2.0.0] but it does not match the constraint.
oxid6_apache_1      |     - ocramius/package-versions 1.9.0 requires php ^7.4.0 -> your php version (7.3.24) does not satisfy that requirement.
oxid6_apache_1      |     - oxid-esales/oxideshop-metapackage-ce v6.2.2 requires ocramius/package-versions 1.4.2|1.5.1|1.9.0 -> satisfiable by ocramius/package-versions[1.4.2, 1.5.1, 1.9.0].
oxid6_apache_1      |     - Root composer.json requires oxid-esales/oxideshop-metapackage-ce v6.2.2 -> satisfiable by oxid-esales/oxideshop-metapackage-ce[v6.2.2].
oxid6_apache_1      | 
oxid6_apache_1      | ocramius/package-versions only provides support for Composer 2 in 1.8+, which requires PHP 7.4.
oxid6_apache_1      | If you can not upgrade PHP you can require composer/package-versions-deprecated to resolve this with PHP 7.0+.
oxid6_apache_1      | 
oxid6_apache_1      | You are using Composer 2, which some of your plugins seem to be incompatible with. Make sure you update your plugins or report a plugin-issue to ask them to support Composer 2.
oxid6_apache_1      | run-parts: /entrypoint.d/010-oxid.sh exited with return code 2
```